### PR TITLE
Add minimal LSP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
-.wasm
+*.wasm
 grammars
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "beancount"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.0.6"
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Zed Beancount
 
 This extension adds support for the [Beancount](https://github.com/beancount/beancount) language.
+
+## Setup
+
+By default this extension just provides syntax highlighting for `.beancount` and `.bean` files, but also optional support for [`beancount-language-server`](https://github.com/polarmutex/beancount-language-server) as well.
+
+To use that you will need `beancount` and `beancount-language-server` available in your path.  For example, on mac:
+
+```
+brew install beancount beancount-language-server
+```

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ To use that you will need `beancount` and `beancount-language-server` available 
 ```
 brew install beancount beancount-language-server
 ```
+
+With that installed Zed will show Diagnostic information inline and in the Zed Diagnostics Panel like this:
+
+![beancount-zed-extension-screenshot](https://github.com/user-attachments/assets/bd6a3ac8-9196-4954-ab33-4ed969189cfa)

--- a/extension.toml
+++ b/extension.toml
@@ -9,3 +9,7 @@ repository = "https://github.com/zed-extensions/beancount"
 [grammars.beancount]
 repository = "https://github.com/polarmutex/tree-sitter-beancount"
 commit = "c25f8034c977681653a8acd541c8b4877a58f474"
+
+[language_servers.beancount]
+name = "Beancount LSP"
+language = "Beancount"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,39 @@
+use zed_extension_api::{self as zed, LanguageServerId};
+
+struct BeancountExtension {}
+
+impl BeancountExtension {
+    fn language_server_binary_path(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> zed::Result<String> {
+        if let Some(path) = worktree.which("beancount-language-server") {
+            return Ok(path);
+        }
+
+        return Err("Beancount language server not installed".to_string());
+    }
+}
+impl zed::Extension for BeancountExtension {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        BeancountExtension {}
+    }
+
+    fn language_server_command(
+        &mut self,
+        language_server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> zed_extension_api::Result<zed_extension_api::Command> {
+        Ok(zed::Command {
+            command: self.language_server_binary_path(language_server_id, worktree)?,
+            args: vec![],
+            env: Default::default(),
+        })
+    }
+}
+
+zed::register_extension!(BeancountExtension);


### PR DESCRIPTION
This adds minimal LSP support for beancount files if the [`beancount-language-server`](https://github.com/polarmutex/beancount-language-server) is already installed in the `$PATH`.

I looked at following the existing pattern for installing the language server from the GitHub repo. However, the Mac and Linux archives are `.tar.xz` files which is not supported in the `DownloadedFileType` enum.