### PR TITLE
Bump beancount extension to v0.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beancount"
-version = "0.0.1"
+version = "0.0.4"
 edition = "2021"
 
 [lib]
@@ -8,4 +8,3 @@ crate-type = ["cdylib"]
 
 [dependencies]
 zed_extension_api = "0.0.6"
-

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "beancount"
 name = "Beancount"
 description = "Beancount support."
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>", "Marshall Bowers <marshall@zed.dev>"]
 repository = "https://github.com/zed-extensions/beancount"


### PR DESCRIPTION
Includes:
- https://github.com/zed-extensions/beancount/pull/3