### PR TITLE
Add Lsp configuration options support for Zed Beancount extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beancount"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beancount"
-version = "0.0.5"
+version = "0.0.4"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This extension adds support for the [Beancount](https://github.com/beancount/bea
 
 By default this extension just provides syntax highlighting for `.beancount` and `.bean` files, but also optional support for [`beancount-language-server`](https://github.com/polarmutex/beancount-language-server) as well.
 
-To use that you will need `beancount` and `beancount-language-server` available in your path.  For example, on mac:
+To use that you will need `beancount` and `beancount-language-server` available in your path. For example, on mac:
 
 ```
 brew install beancount beancount-language-server
@@ -15,3 +15,21 @@ brew install beancount beancount-language-server
 With that installed Zed will show Diagnostic information inline and in the Zed Diagnostics Panel like this:
 
 ![beancount-zed-extension-screenshot](https://github.com/user-attachments/assets/bd6a3ac8-9196-4954-ab33-4ed969189cfa)
+
+## Configuration
+
+You can configure the beancount-language-server by adding initialization options to either your project settings or global Zed settings:
+
+```json
+// Project-specific: .zed/settings.json
+// Global: ~/.config/zed/settings.json
+{
+  "lsp": {
+    "beancount": {
+      "initialization_options": {
+        "journal_file": "/path/to/main.beancount"
+      }
+    }
+  }
+}
+```

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "beancount"
 name = "Beancount"
 description = "Beancount support."
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>", "Marshall Bowers <marshall@zed.dev>"]
 repository = "https://github.com/zed-extensions/beancount"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "beancount"
 name = "Beancount"
 description = "Beancount support."
-version = "0.0.5"
+version = "0.0.4"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>", "Marshall Bowers <marshall@zed.dev>"]
 repository = "https://github.com/zed-extensions/beancount"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-use zed_extension_api::{self as zed, LanguageServerId};
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId};
 
 struct BeancountExtension {}
 
 impl BeancountExtension {
     fn language_server_binary_path(
         &mut self,
-        language_server_id: &LanguageServerId,
+        _language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> zed::Result<String> {
         if let Some(path) = worktree.which("beancount-language-server") {
@@ -33,6 +33,18 @@ impl zed::Extension for BeancountExtension {
             args: vec![],
             env: Default::default(),
         })
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        server_id: &LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 }
 


### PR DESCRIPTION
This PR adds configuration options support for the Zed Beancount extension, allowing users to customize extension behavior through settings.
The config options will looks like below:
```json
{
  "lsp": {
    "beancount": {
      "initialization_options": {
        "journal_file": "/path/to/main.beancount"
      }
    }
  }
}
```